### PR TITLE
Added configurable successful exit codes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,7 @@ function spawn(command, args, options) {
     var deferred = q.defer();
     var result = {};
     var cp;
+    var successfulExitCodes = options.successfulExitCodes || [0];
 
     cp = childProcess.spawn(command, args, options);
 
@@ -119,7 +120,7 @@ function spawn(command, args, options) {
     cp.on('error', deferred.reject);
 
     cp.on('close', function (code) {
-        if (code !== 0) {
+        if (successfulExitCodes.indexOf(code) !== -1) {
             var commandStr = command + (args.length ? (' ' + args.join(' ')) : '');
             var err = {
                 code: code,

--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ function spawn(command, args, options) {
     cp.on('error', deferred.reject);
 
     cp.on('close', function (code) {
-        if (successfulExitCodes.indexOf(code) !== -1) {
+        if (successfulExitCodes.indexOf(code) === -1) {
             var commandStr = command + (args.length ? (' ' + args.join(' ')) : '');
             var err = {
                 code: code,


### PR DESCRIPTION
spawn can now have any number of successful exit codes.

add an array of successful exit codes to the options hash:

    var spawn = require("child-process-promise").spawn
    spawn("ls", null, {successfulExitCodes: [0,1]} );

resolves #12