### PR TITLE
Enable es5: initial draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ reports
 target
 docs
 logs
+lib-es5

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+if (require('node-version').major >= 4) {
+  module.exports = require('./lib');
+} else {
+  global.Promise = require('promise-polyfill');
+  module.exports = require('./lib-es5');
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,10 +3,6 @@ var child_process = require('child_process');
 var ChildProcessPromise = require('./ChildProcessPromise');
 var slice = Array.prototype.slice;
 
-if (!global.Promise) {
-    throw new Error('Native Promise implementation not found. You must use a newer version of Node.js or install a ES2015 Promise polyfill.');
-}
-
 /**
  * Promise wrapper for exec, execFile
  *

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "child-process-promise",
   "description": "Simple wrapper around the \"child_process\" module that makes use of promises",
-  "main": "lib/index.js",
+  "main": "./index.js",
   "files": [
     "lib",
     "Readme.md"
@@ -9,7 +9,8 @@
   "scripts": {
     "lint": "eslint lib/*js test/*js",
     "test": "npm run mocha",
-    "mocha": "node_modules/.bin/mocha --ui bdd --reporter spec ./test/"
+    "mocha": "node_modules/.bin/mocha --ui bdd --reporter spec ./test/",
+    "prepublish": "node_modules/.bin/babel lib --out-dir lib-es5"
   },
   "repository": {
     "type": "git",
@@ -28,15 +29,23 @@
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-version": "^1.0.0",
+    "promise-polyfill": "^6.0.1"
+  },
   "devDependencies": {
+    "babel": "^6.5.2",
+    "babel-plugin-check-es2015-constants": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.10.1",
+    "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
     "eslint": "^0.10.2",
     "jshint": "^2.9.1",
     "mocha": "^2.4.5"
   },
   "version": "2.0.3",
-  "engines": {
-    "node": ">=4"
+  "babel": {
+    "presets": ["es2015"],
+    "plugins": ["check-es2015-constants", "transform-es2015-block-scoping"]
   }
 }


### PR DESCRIPTION
 - change main entry to ./index.js
 - add logic to dynamically export the appropriate lib version and polyfill
   'Promise' if necessary
 - add prepublish script
 - add node-version and promise-polyfill dependencies
 - add necessary babel dev dependencies
 - remove engine declaration in package.json
 - add babel configuration