### PR TITLE
add .npmignore file to ensure lib-es5 gets published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+*.iml
+.DS_Store
+.idea
+*.log
+temp
+node_modules
+pids
+reports
+target
+docs
+logs


### PR DESCRIPTION
 - See npm issue for explanation  
   https://github.com/npm/npm/issues/3571  
   In short, files matched in .gitignore are ignored by npm publish if .npmignore is not found