### PR TITLE
use cross-spawn for windows #8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var child_process = require('child_process');
+var crossSpawn = require('cross-spawn');
 var ChildProcessPromise = require('./ChildProcessPromise');
 var slice = Array.prototype.slice;
 
@@ -84,7 +85,7 @@ function doSpawn(method, command, args, options) {
 
     var successfulExitCodes = (options && options.successfulExitCodes) || [0];
 
-    cp = child_process[method](command, args, options);
+    cp = method(command, args, options);
 
     // Don't return the whole Buffered result by default.
     var captureStdout = false;
@@ -156,11 +157,11 @@ function doSpawn(method, command, args, options) {
 }
 
 function spawn(command, args, options) {
-    return doSpawn('spawn', command, args, options);
+    return doSpawn(crossSpawn, command, args, options);
 }
 
 function fork(modulePath, args, options) {
-    return doSpawn('fork', modulePath, args, options);
+    return doSpawn(child_process.fork, modulePath, args, options);
 }
 
 exports.exec = exec;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
+    "cross-spawn": "^4.0.2",
     "node-version": "^1.0.0",
     "promise-polyfill": "^6.0.1"
   },


### PR DESCRIPTION
Very simple `spawn` call works fine on both Windows and macOS machines.

All the tests succeed on my macOS machine.

But on Windows, I can see some failures because of the reasons below.

1. `spawn cat ENOENT`, it's windows. there's no cat :cat:
2. `Uncaught AssertionError: expected 'hello\r\n' to equal 'hello\n'` line break differs. yeah. got it.
3. ` Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.` dunno why.
4. fails at `should support the "capture" (stdout and stderr) option for spawn` but dunno why.

But if these tests are not serious problems, I think this PR can be merged and you can fix tests later(before a new release at least)

## Full test result on Windows
```
  1) child-process-promise exec should resolve with process info:
     Error: Command failed: cat C:\Users\tintypemolly\workspace\child-process-promise\test\fixtures\foo.txt
'cat'��(��) ���� �Ǵ� �ܺ� ����, ������ �� �ִ� ���α׷�, �Ǵ�
��ġ ������ �ƴմϴ�.
 `cat C:\Users\tintypemolly\workspace\child-process-promise\test\fixtures\foo.txt` (exited with error code 1)
      at ChildProcess.exithandler (child_process.js:206:12)
      at maybeClose (internal/child_process.js:877:16)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)

  2) child-process-promise exec should be compatible with previous version of child-process-promise:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
      at Timeout.<anonymous> (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\mocha\lib\runnable.js:226:19)

  3) child-process-promise spawn should resolve with process info:
     Error: spawn cat ENOENT
      at notFoundError (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:11:11)
      at verifyENOENT (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:46:16)
      at ChildProcess.cp.emit (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:33:19)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)

  4) child-process-promise spawn should support the "capture" (stdout only) option for spawn:
     Error: spawn cat ENOENT
      at notFoundError (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:11:11)
      at verifyENOENT (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:46:16)
      at ChildProcess.cp.emit (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:33:19)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)

  5) child-process-promise spawn should support the "capture" (stdout and stderr) option for spawn:
     Error: spawn cat ENOENT
      at notFoundError (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:11:11)
      at verifyENOENT (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:46:16)
      at ChildProcess.cp.emit (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:33:19)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)

  6) child-process-promise spawn should support the "capture" (stdout and stderr) option for spawn with rejection:
     Uncaught AssertionError: expected undefined to equal ''
      at Assertion.assertEqual (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\core\assertions.js:487:12)
      at Assertion.ctx.(anonymous function) [as equal] (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at C:\Users\tintypemolly\workspace\child-process-promise\test\test.js:274:46
      at process._tickCallback (internal/process/next_tick.js:103:7)

  7) child-process-promise spawn should handle rejection correctly with catch:
     AssertionError: expected 'Error: spawn cat ENOENT' to include 'C:\\Users\\tintypemolly\\workspace\\child-process-promise\\test\\THIS_FILE_DOES_NOT_EXIST'
      at Assertion.include (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\core\assertions.js:230:10)
      at Assertion.assert (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\utils\addChainableMethod.js:84:49)
      at C:\Users\tintypemolly\workspace\child-process-promise\test\test.js:292:45
      at process._tickCallback (internal/process/next_tick.js:103:7)

  8) child-process-promise spawn should handle rejection correctly with fail:
     AssertionError: expected 'Error: spawn cat ENOENT' to include 'C:\\Users\\tintypemolly\\workspace\\child-process-promise\\test\\THIS_FILE_DOES_NOT_EXIST'
      at Assertion.include (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\core\assertions.js:230:10)
      at Assertion.assert (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\utils\addChainableMethod.js:84:49)
      at C:\Users\tintypemolly\workspace\child-process-promise\test\test.js:307:45
      at process._tickCallback (internal/process/next_tick.js:103:7)

  9) child-process-promise spawn should be compatible with previous version of child-process-promise:
     Uncaught AssertionError: expected 'hello\r\n' to equal 'hello\n'
      at Function.assert.equal (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\chai\lib\chai\interface\assert.js:126:10)
      at C:\Users\tintypemolly\workspace\child-process-promise\test\test.js:326:28
      at process._tickCallback (internal/process/next_tick.js:103:7)

  10) child-process-promise spawn should provide the exit code for success:
     Error: spawn cat ENOENT
      at notFoundError (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:11:11)
      at verifyENOENT (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:46:16)
      at ChildProcess.cp.emit (C:\Users\tintypemolly\workspace\child-process-promise\node_modules\cross-spawn\lib\enoent.js:33:19)
      at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
```