### PR TITLE
Implemented ChildprocessError class to be conform to Promises/A+ spec

### DIFF
--- a/lib/ChildProcessError.js
+++ b/lib/ChildProcessError.js
@@ -1,0 +1,18 @@
+'use strict';
+
+
+class ChildProcessError extends Error {
+    constructor(message, code, childProcess, stdout, stderr) {
+        super(message);
+        Error.captureStackTrace(this, this.constructor);
+        this.name = this.constructor.name;
+        this.code = code;
+        this.childProcess = childProcess;
+        this.stdout = stdout;
+        this.stderr = stderr;
+    }
+}
+
+
+
+module.exports = ChildProcessError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@
 var child_process = require('child_process');
 var crossSpawn = require('cross-spawn');
 var ChildProcessPromise = require('./ChildProcessPromise');
+var ChildProcessError = require('./ChildProcessError');
+
 var slice = Array.prototype.slice;
 
 /**
@@ -28,8 +30,8 @@ function doExec(method, args) {
             err.message += ' `' + commandStr + '` (exited with error code ' + err.code + ')';
             err.stdout = stdout;
             err.stderr = stderr;
-
-            reject(err);
+            var cpError = new ChildProcessError(err.message, err.code, child_process, stdout, stderr);
+            reject(cpError);
         } else {
             resolve({
                 childProcess: cp,
@@ -45,24 +47,24 @@ function doExec(method, args) {
 }
 
 /**
-* `exec` as Promised
-*
-* @param {String} command
-* @param {Object} options
-* @return {Promise}
-*/
+ * `exec` as Promised
+ *
+ * @param {String} command
+ * @param {Object} options
+ * @return {Promise}
+ */
 function exec() {
     return doExec('exec', arguments);
 }
 
 /**
-* `execFile` as Promised
-*
-* @param {String} command
-* @param {Array} args
-* @param {Object} options
-* @return {Promise}
-*/
+ * `execFile` as Promised
+ *
+ * @param {String} command
+ * @param {Array} args
+ * @param {Object} options
+ * @return {Promise}
+ */
 function execFile() {
     return doExec('execFile', arguments);
 }
@@ -108,7 +110,7 @@ function doSpawn(method, command, args, options) {
     if (captureStdout) {
         result.stdout = '';
 
-        cp.stdout.on('data', function (data) {
+        cp.stdout.on('data', function(data) {
             result.stdout += data;
         });
     }
@@ -116,24 +118,18 @@ function doSpawn(method, command, args, options) {
     if (captureStderr) {
         result.stderr = '';
 
-        cp.stderr.on('data', function (data) {
+        cp.stderr.on('data', function(data) {
             result.stderr += data;
         });
     }
 
     cp.on('error', reject);
 
-    cp.on('close', function (code) {
+    cp.on('close', function(code) {
         if (successfulExitCodes.indexOf(code) === -1) {
             var commandStr = command + (args.length ? (' ' + args.join(' ')) : '');
-            var err = {
-                code: code,
-                message: '`' + commandStr + '` failed with code ' + code,
-                childProcess: cp,
-                toString() {
-                    return this.message;
-                }
-            };
+            var message = '`' + commandStr + '` failed with code ' + code;
+            var err = new ChildProcessError(message, code, cp);
 
             if (captureStderr) {
                 err.stderr = result.stderr.toString();
@@ -144,8 +140,7 @@ function doSpawn(method, command, args, options) {
             }
 
             reject(err);
-        }
-        else {
+        } else {
             result.code = code;
             resolve(result);
         }


### PR DESCRIPTION
Here is a really basic implementation of ChildProcessError class to be returned on rejection. Added some tests adjustments.