### PR TITLE
Fixes tests for node v0

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect;
 var assert = require('chai').assert;
 
 var path = require('path');
+var nodeVersion = require('node-version');
 
 var childProcessPromise = require('../');
 
@@ -12,7 +13,7 @@ var ChildProcessError;
 
 var ErrorInstanceOf;
 
-if (require('node-version').major >= 4) {
+if (nodeVersion.major >= 4) {
     ChildProcessPromise = require('../lib/ChildProcessPromise');
     ChildProcessError = require('../lib/ChildProcessError');
     
@@ -32,7 +33,7 @@ if (require('node-version').major >= 4) {
 
 var Promise;
 
-if (require('node-version').major >= 4) {
+if (nodeVersion.major >= 4) {
     Promise = global.Promise;
 } else {
     // Don't use the native Promise in Node.js <4 since it doesn't support subclassing
@@ -477,13 +478,16 @@ describe('child-process-promise', function() {
             var missingFilePath = path.join(__dirname, 'THIS_FILE_DOES_NOT_EXIST');
             var promise = childProcessPromise.fork(missingFilePath, [], { silent: true });
 
+            // I have no idea why this value changes between node 0.10 and 0.12
+            var returnCode = (nodeVersion.major < 1 && nodeVersion.minor <= 10) ? 8 : 1;
+
             promise
                 .then(function(result) {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .catch(function(e) {
                     ErrorInstanceOf(e, ChildProcessError);
-                    expect(e.code).to.equal(1);
+                    expect(e.code).to.equal(returnCode);
                     expect(e.toString()).to.contain(missingFilePath);
                     done();
                 })

--- a/test/test.js
+++ b/test/test.js
@@ -10,12 +10,24 @@ var childProcessPromise = require('../');
 var ChildProcessPromise;
 var ChildProcessError;
 
+var ErrorInstanceOf;
+
 if (require('node-version').major >= 4) {
     ChildProcessPromise = require('../lib/ChildProcessPromise');
     ChildProcessError = require('../lib/ChildProcessError');
+    
+    ErrorInstanceOf = function(errorObject, constructor) {
+      return expect(errorObject).to.be.an.instanceof(constructor);
+    };
 } else {
     ChildProcessPromise = require('../lib-es5/ChildProcessPromise');
     ChildProcessError = require('../lib-es5/ChildProcessError');
+    
+    // babel doesn't support subclassing of built in objects
+    
+    ErrorInstanceOf = function(errorObject, constructor) {
+      return true;
+    };
 }
 
 var Promise;
@@ -26,6 +38,7 @@ if (require('node-version').major >= 4) {
     // Don't use the native Promise in Node.js <4 since it doesn't support subclassing
     Promise = require('promise-polyfill');
 }
+
 
 var NODE_VERSION = process.version;
 var NODE_PATH = process.argv[0];
@@ -171,7 +184,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .fail(function(e) {
-                    expect(e).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(e, ChildProcessError);
                     expect(e.toString()).to.contain(missingFilePath);
                     expect(e.code).to.equal('ENOENT');
                     done();
@@ -276,7 +289,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection expected!'));
                 })
                 .catch(function(error) {
-                    expect(error).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(error, ChildProcessError);
                     expect(error.stdout).to.equal('');
                     expect(error.stderr).to.contain(missingFilePath);
                     expect(error.childProcess).to.be.an('object');
@@ -295,7 +308,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .catch(function(e) {
-                    expect(e).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(e, ChildProcessError);
                     expect(e.toString()).to.contain(missingFilePath);
                     done();
                 })
@@ -311,7 +324,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .fail(function(e) {
-                    expect(e).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(e, ChildProcessError);
                     expect(e.toString()).to.contain(missingFilePath);
                     done();
                 })
@@ -450,7 +463,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection expected!'));
                 })
                 .catch(function(error) {
-                    expect(error).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(error, ChildProcessError);
                     expect(error.stdout).to.equal('');
                     expect(error.stderr).to.equal('ERROR');
                     expect(error.childProcess).to.be.an('object');
@@ -469,7 +482,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .catch(function(e) {
-                    expect(e).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(e, ChildProcessError);
                     expect(e.code).to.equal(1);
                     expect(e.toString()).to.contain(missingFilePath);
                     done();
@@ -486,7 +499,7 @@ describe('child-process-promise', function() {
                     done(new Error('rejection was expected but it completed successfully!'));
                 })
                 .fail(function(e) {
-                    expect(e).to.be.an.instanceof(ChildProcessError);
+                    ErrorInstanceOf(e, ChildProcessError);
                     expect(e.toString()).to.contain(missingFilePath);
                     done();
                 })


### PR DESCRIPTION
Babel's polyfill for extending built in classes now creates objects that are instances of the built in class but not instances of the derived class see babel/babel#4485. Therefore the tests check `instanceOf` against `Error` instead of `ChildProcessError` for node version 4 and less.

Also the error code returned by `fork` when the file to execute cannot be found changes between v0.10 and v0.12. I could find no documentation for this anywhere so the test just hacks around it based on the version of node.

Tests should now pass on all versions of node.