### PR TITLE
Print feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 temp
 node_modules
+package-lock.json
 pids
 reports
 target

--- a/README.md
+++ b/README.md
@@ -72,3 +72,21 @@ spawn('echo', ['hello'], { capture: [ 'stdout', 'stderr' ]})
         console.error('[spawn] stderr: ', err.stderr);
     });
 ```
+
+#### print
+Type: `Array`  
+Default: `[]`
+
+Pass an additional `print` option to **print automatically** the result of `stdout` and/or `stderr`
+
+```javascript
+var spawn = require('child-process-promise').spawn;
+
+spawn('echo', ['hello'], { print: [ 'stdout', 'stderr' ]})
+    .then(function (result) {
+        // then block
+    })
+    .catch(function (err) {
+        // error block
+    });
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,22 @@ function doSpawn(method, command, args, options) {
         }
     }
 
+    // Don't print the whole Buffered by default.
+    var printStdout = false;
+    var printStderr = false;
+
+    var print = options && options.print;
+    if (print) {
+        for (var i = 0, len = print.length; i < len; i++) {
+            var cur = print[i];
+            if (cur === 'stdout') {
+                printStdout = true;
+            } else if (cur === 'stderr') {
+                printStderr = true;
+            }
+        }
+    }
+
     result.childProcess = cp;
 
     if (captureStdout) {
@@ -120,6 +136,18 @@ function doSpawn(method, command, args, options) {
 
         cp.stderr.on('data', function(data) {
             result.stderr += data;
+        });
+    }
+
+    if (printStdout) {
+        cp.stdout.on('data', function (data) {
+            process.stdout.write(data.toString())
+        });
+    }
+
+    if (printStderr) {
+        cp.stderr.on('data', function(data) {
+            process.stdout.write(data.toString())
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-preset-es2015": "^6.13.2",
     "chai": "^3.5.0",
     "eslint": "^0.10.2",
+    "intercept-stdout": "^0.1.2",
     "jshint": "^2.9.1",
     "mocha": "^2.4.5"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ describe('child-process-promise', function() {
                 .catch(done);
         });
 
-        it('should support the "capture" (stdout only) option for spawn', function(done) {
+        it('should support the "capture" (stdout only) option for fork', function(done) {
             var scriptpath = path.join(__dirname, 'fixtures/fork.js');
             var promise = childProcessPromise.fork(scriptpath, ['foo'], {
                 silent: true,
@@ -416,7 +416,7 @@ describe('child-process-promise', function() {
                 .catch(done);
         });
 
-        it('should support the "capture" (stdout and stderr) option for spawn', function(done) {
+        it('should support the "capture" (stdout and stderr) option for fork', function(done) {
             var scriptpath = path.join(__dirname, 'fixtures/fork.js');
             var promise = childProcessPromise.fork(scriptpath, ['foo'], {
                 silent: true,
@@ -436,7 +436,7 @@ describe('child-process-promise', function() {
                 .catch(done);
         });
 
-        it('should support the "capture" (stdout and stderr) option for spawn with rejection', function(done) {
+        it('should support the "capture" (stdout and stderr) option for fork with rejection', function(done) {
             var scriptpath = path.join(__dirname, 'fixtures/fork.js');
             var promise = childProcessPromise.fork(scriptpath, ['ERROR'], {
                 silent: true,


### PR DESCRIPTION
Recently I have used this library to run some processes and I missed a possible feature: Instead to catch the `stdout` and `stderr` to print them in the console (typically when you run a script), the `child-process-promise` library could have this feature inside to do the life easier for developers 😄 

In this PR I have added this possible feature that I hope that it is well received.