### PR TITLE
Handle exit event in spawn()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
 'use strict';
 
-if (require('node-version').major >= 4) {
-    module.exports = require('./lib');
-} else {
-    module.exports = require('./lib-es5');
-}
+module.exports = require('./lib');

--- a/lib/ChildProcessPromise.js
+++ b/lib/ChildProcessPromise.js
@@ -1,14 +1,5 @@
 'use strict';
 
-var Promise;
-
-if (require('node-version').major >= 4) {
-    Promise = global.Promise;
-} else {
-    // Don't use the native Promise in Node.js <4 since it doesn't support subclassing
-    Promise = require('promise-polyfill');
-}
-
 class ChildProcessPromise extends Promise {
     constructor(executor) {
         var resolve;

--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ function doSpawn(method, command, args, options) {
 
     cp.on('error', reject);
 
-    cp.on('close', function(code) {
+    var closeHandler = function(code) {
         if (successfulExitCodes.indexOf(code) === -1) {
             var commandStr = command + (args.length ? (' ' + args.join(' ')) : '');
             var message = '`' + commandStr + '` failed with code ' + code;
@@ -144,7 +144,10 @@ function doSpawn(method, command, args, options) {
             result.code = code;
             resolve(result);
         }
-    });
+    };
+
+    cp.on('close', closeHandler);
+    cp.on('exit', closeHandler);
 
     cpPromise.childProcess = cp;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "child-process-promise",
   "description": "Simple wrapper around the \"child_process\" module that makes use of promises",
-  "main": "./index.js",
+  "main": "index.js",
   "files": [
     "lib",
     "lib-es5",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "registry": "http://registry.npmjs.org/"
   },
   "dependencies": {
-    "cross-spawn": "^4.0.2",
-    "node-version": "^1.0.0",
-    "promise-polyfill": "^6.0.1"
+    "cross-spawn": "^7.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/test/test.js
+++ b/test/test.js
@@ -7,25 +7,8 @@ var path = require('path');
 
 var childProcessPromise = require('../');
 
-var ChildProcessPromise;
-var ChildProcessError;
-
-if (require('node-version').major >= 4) {
-    ChildProcessPromise = require('../lib/ChildProcessPromise');
-    ChildProcessError = require('../lib/ChildProcessError');
-} else {
-    ChildProcessPromise = require('../lib-es5/ChildProcessPromise');
-    ChildProcessError = require('../lib-es5/ChildProcessError');
-}
-
-var Promise;
-
-if (require('node-version').major >= 4) {
-    Promise = global.Promise;
-} else {
-    // Don't use the native Promise in Node.js <4 since it doesn't support subclassing
-    Promise = require('promise-polyfill');
-}
+var ChildProcessPromise = require('../lib/ChildProcessPromise');
+var ChildProcessError = require('../lib/ChildProcessError');
 
 var NODE_VERSION = process.version;
 var NODE_PATH = process.argv[0];


### PR DESCRIPTION
This PR fixes issue #26. 
There are cases when the `close` event won't fire after a process terminates, leaving the promise in a forever pending state, so I added the same handler function to the `exit` event as well.